### PR TITLE
ci: add Python and OS matrix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,15 +8,22 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.10', '3.11', '3.12', '3.13']
+        os: ['ubuntu-latest', 'windows-latest']
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.13'
+          python-version: ${{ matrix.python-version }}
+          allow-prerelease: true
       - name: Install
+        shell: bash
         run: |
           python -m pip install --upgrade pip
           pip install pytest
       - name: Tests
+        shell: bash
         run: pytest -q


### PR DESCRIPTION
## Summary
- test against Python 3.10-3.13 on Ubuntu and Windows
- use setup-python v5 with allow-prerelease for Python 3.13.7
- run Windows steps under bash

## Testing
- `python -m pip install -U pip pytest`
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c236fa6c6c8321af013f2f999e0ac9