### PR TITLE
Document Python 3.10-3.13 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Instead of one-shot red teaming, AAL measures how models and defenses learn unde
 
 ## Quick start
 
+AAL supports Python 3.10–3.13. Continuous integration tests run on Ubuntu and on Windows using Git Bash.
+
 ```bash
 python -m venv .venv && . .venv/bin/activate
 pip install -U pip pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,12 @@ description = "Adaptive Adversarial Looping - learning under attack"
 authors = [{name = "AAL Contributors"}]
 readme = "README.md"
 requires-python = ">=3.10"
+classifiers = [
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
## Summary
- Declare support for Python 3.10–3.13 in project classifiers
- Note in README that CI tests run on Python 3.10–3.13 including Git Bash on Windows

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c23875282c8321a1b8cb8421ac1e54